### PR TITLE
Docker configuration 81

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Do kompilacji i uruchomienia aplikacji lokalnie potrzebne są następujące zale
 
 - Java 8 (JDK 8)
 - NodeJS (wersja 9.x)
-- PostgreSQL (przynajmniej wersja 9.4). Należy stworzyć bazę o nazwie `rekolekcjedb`, lub skonfigurować aplikację do połączenia z inną bazą.
+- [Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+- [Docker-compose](https://docs.docker.com/compose/install/)
+
+Jeśli chcesz uruchomić bazę danych lokalnie/nie masz Dockera, potrzebny jest:
+- PostgreSQL (przynajmniej wersja 9.4). Należy stworzyć bazę o nazwie `rekolekcjedb`,
+która będzie działać na porcie `localhost:5430` lub skonfigurować aplikację do połączenia z inną bazą.
 
 
 ## Uruchomienie
@@ -26,18 +31,49 @@ Aplikację można uruchomić w dwóch trybach:
 - produkcyjnym - system budowany jest jako pojedyncza aplikacja, która łaczy się z produkcyjną bazą danych i wymaga konfiguracji kont uzytkownikow
 - developerskim - możliwe jest niezależne uruchomienie aplikacji backendowej i frontendowej, oraz użycie innej bazy danych, na przykład pamieciowej lub testowej
 
+**Uwaga**: <br/>
+Wykorzystując kontenery dockera z Postgres, upewnij się, że na twojej maszynie
+nie jest uruchomiona instancja PostgreSQL.
+
+`sudo service postgresql status`
+
+Jeśli jest, zatrzymaj ją, aby uniknąć ewentualnych konfliktów bindowania portów:
+
+`sudo service postgresql stop`
+
 ### Tryb produkcyjny
 
-Aby uruchomić aplikację:
+Aby uruchomić aplikację: <br/>
+Uruchom terminal i po wejściu do głównego katalogu projektu wpisz:
+
+```$xslt
+./env.sh start
+```
+a następnie
 ```$xslt
 ./gradlew bootRun
 ```
 
-Aplikacja bedzie dostepna na porcie wyswietlonym w konsoli (`http://localhost:5000`)
+
+Skrypt `./env.sh start` zbuduje kontenery dockerowe z bazą danych PostreSQL wymagane do prawidłowego działania aplikacji
+oraz prawidłowego wykonania się testów integracyjnych. <br/>
+Skrypt `./gradlew bootRun` zbuduje `fat jar` i go uruchomi. <br/>
+Aplikacja bedzie dostepna na porcie wyswietlonym w konsoli (`http://localhost:5000`) <br/>
+Po zakończonej pracy wykonaj skrypt:
+`./env.sh wipe`, co spowoduje usunięcie powstałych wcześniej kontenerów. <br/>
+
+#### Uruchomienie z dockerem
+Możliwe jest uruchomienie aplikacji w kontenerze dockerowym. <br/>
+Aby to zrobić, będąc w katalogu głównym projektu wykonaj komendę:
+`docker-compose up`. <br/>
+Aplikacja dostępna będzie na `localhost:5000`
+Po zakończonej pracy wykonaj `docker-compose down`.
 
 ### Tryb developerski
 
-Aby uruchomic serwer (engine)
+
+##### Uruchomienie backendu (engine)
+Będąc w katalogu głównym projektu wpisz w terminalu:
 ```$xslt
 ./gradlew bootRun
 ```
@@ -50,12 +86,13 @@ lub w trybie developerskim, na pamięciowej bazie danych:
 Backend bedzie dostepny na porcie `5000`.
 Domyślną konfigurację można zmienić poprzez utworzenie pliku `application-local.yml` i nadpisanie w nim odpowiednich properties.
 
-Aby uruchomic frontend
+#### Uruchomienie frontendu (webapp):
+Będąc w katalogu `./rekolekcje-webapp/src/app/` wpisz w terminalu:
 ```$xslt
 npm start
 ```
 
-Frontend bedzie dostepny na porcie `4200`.
+Frontend będzie dostepny na porcie `4200`. <br/>
 
 ### Testy automatyczne
 
@@ -66,6 +103,8 @@ Wszystkie testy z konsoli:
 ```$xslt
 ./gradlew verify
 ```
+Pamiętaj, że przed wywołaniem testów jednostkowych musi zostać zbudowany
+kontener dockerowy z bazą danych!  (`./enh.sh start`)
 
 Testy jednostkowe:
 ```$xslt

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Wszystkie testy z konsoli:
 ```$xslt
 ./gradlew verify
 ```
-Pamiętaj, że przed wywołaniem testów jednostkowych musi zostać zbudowany
+Pamiętaj, że przed wywołaniem testów integracyjnych musi zostać zbudowany
 kontener dockerowy z bazą danych!  (`./enh.sh start`)
 
 Testy jednostkowe:

--- a/README.md
+++ b/README.md
@@ -31,16 +31,6 @@ Aplikację można uruchomić w dwóch trybach:
 - produkcyjnym - system budowany jest jako pojedyncza aplikacja, która łaczy się z produkcyjną bazą danych i wymaga konfiguracji kont uzytkownikow
 - developerskim - możliwe jest niezależne uruchomienie aplikacji backendowej i frontendowej, oraz użycie innej bazy danych, na przykład pamieciowej lub testowej
 
-**Uwaga**: <br/>
-Wykorzystując kontenery dockera z Postgres, upewnij się, że na twojej maszynie
-nie jest uruchomiona instancja PostgreSQL.
-
-`sudo service postgresql status`
-
-Jeśli jest, zatrzymaj ją, aby uniknąć ewentualnych konfliktów bindowania portów:
-
-`sudo service postgresql stop`
-
 ### Tryb produkcyjny
 
 Aby uruchomić aplikację: <br/>
@@ -57,6 +47,7 @@ a następnie
 
 Skrypt `./env.sh start` zbuduje kontenery dockerowe z bazą danych PostreSQL wymagane do prawidłowego działania aplikacji
 oraz prawidłowego wykonania się testów integracyjnych. <br/>
+Produkcyjna baza danych będzie dostępna przez `localhost:5430`, a baza testowa na `localhost:5431`. <br/>
 Skrypt `./gradlew bootRun` zbuduje `fat jar` i go uruchomi. <br/>
 Aplikacja bedzie dostepna na porcie wyswietlonym w konsoli (`http://localhost:5000`) <br/>
 Po zakończonej pracy wykonaj skrypt:
@@ -66,7 +57,7 @@ Po zakończonej pracy wykonaj skrypt:
 Możliwe jest uruchomienie aplikacji w kontenerze dockerowym. <br/>
 Aby to zrobić, będąc w katalogu głównym projektu wykonaj komendę:
 `docker-compose up`. <br/>
-Aplikacja dostępna będzie na `localhost:5000`
+Aplikacja dostępna będzie na `localhost:5000`, a jej baza na `localhost:5433`.
 Po zakończonej pracy wykonaj `docker-compose down`.
 
 ### Tryb developerski

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     container_name: reko-db
     image: postgres
     ports:
-      - "5432:5432"
+      - "5433:5432"
     networks:
       - reko_network
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.1'
+services:
+  rekolekcje-engine:
+    container_name: reko-engine
+    build: ./rekolekcje-engine/
+    ports:
+      - "5000:5000"
+    links:
+      - rekolekcje-db:database
+    networks:
+      - reko_network
+    environment:
+      - spring.datasource.url=jdbc:postgresql://rekolekcje-db:5432/rekolekcjedb
+    depends_on:
+      - rekolekcje-db
+
+  rekolekcje-db:
+    container_name: reko-db
+    image: postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - reko_network
+    environment:
+      - POSTGRES_DB=rekolekcjedb
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+
+networks:
+  reko_network:
+    driver: bridge

--- a/env.sh
+++ b/env.sh
@@ -7,7 +7,7 @@ if [ "$1" = "start" ] ; then
   echo "DB can be accesed via localhost:5430"
 
   echo "Building Postres container for integration tests..."
-  docker run --name db-rekolekcje-test -p 5431:5432 -e POSTGRES_DB=rekolekcjedb-test -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+  docker run --name db-rekolekcje-test -p 5431:5432 -e POSTGRES_DB=rekolekcjedb-test -e POSTGRES_PASSWORD=postgres -d postgres
   echo "Test DB can be accesed via localhost:5431"
 
 elif [ "$1" = "wipe" ] ; then

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ $1 = "start" ]
+then
+
+echo "Building Postgres container...."
+docker run --name db-rekolekcje -p 5432:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
+
+elif [ $1 = "wipe" ]
+
+then
+
+echo "Stopping all running containers..."
+docker stop $(docker ps -a -q)
+
+echo "Removing all stopped containers..."
+docker rm $(docker ps -a -q)
+
+fi

--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,10 @@
 if [ "$1" = "start" ] ; then
 
   echo "Building Postgres container...."
-  docker run --name db-rekolekcje -p 5432:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
+  docker run --name db-rekolekcje -p 5430:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
+
+  echo "Building Postres container for integration tests..."
+  docker run --name db-rekolekcje-test -p 5433:5432 -e POSTGRES_DB=rekolekcjedb-test -e POSTGRES_PASSWORD=mysecretpassword -d postgres
 
 elif [ "$1" = "wipe" ] ; then
 
@@ -12,5 +15,9 @@ elif [ "$1" = "wipe" ] ; then
 
   echo "Removing all stopped containers..."
   docker rm $(docker ps -a -q)
+
+else
+  echo "Invalid command. Type './env.sh start' or './env.sh wipe'."
+  exit 0
 
 fi

--- a/env.sh
+++ b/env.sh
@@ -4,9 +4,11 @@ if [ "$1" = "start" ] ; then
 
   echo "Building Postgres container...."
   docker run --name db-rekolekcje -p 5430:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
+  echo "DB can be accesed via localhost:5430"
 
   echo "Building Postres container for integration tests..."
-  docker run --name db-rekolekcje-test -p 5433:5432 -e POSTGRES_DB=rekolekcjedb-test -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+  docker run --name db-rekolekcje-test -p 5431:5432 -e POSTGRES_DB=rekolekcjedb-test -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+  echo "Test DB can be accesed via localhost:5431"
 
 elif [ "$1" = "wipe" ] ; then
 

--- a/env.sh
+++ b/env.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
 
-if [ $1 = "start" ]
-then
+if [ "$1" = "start" ] ; then
 
-echo "Building Postgres container...."
-docker run --name db-rekolekcje -p 5432:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
+  echo "Building Postgres container...."
+  docker run --name db-rekolekcje -p 5432:5432 -e POSTGRES_DB=rekolekcjedb -e POSTGRES_PASSWORD=postgres -d postgres
 
-elif [ $1 = "wipe" ]
+elif [ "$1" = "wipe" ] ; then
 
-then
+  echo "Stopping all running containers..."
+  docker stop $(docker ps -a -q)
 
-echo "Stopping all running containers..."
-docker stop $(docker ps -a -q)
-
-echo "Removing all stopped containers..."
-docker rm $(docker ps -a -q)
+  echo "Removing all stopped containers..."
+  docker rm $(docker ps -a -q)
 
 fi

--- a/rekolekcje-engine/Dockerfile
+++ b/rekolekcje-engine/Dockerfile
@@ -1,0 +1,9 @@
+FROM java:8
+
+VOLUME /tmp
+
+ADD ./build/libs/rekolekcje-engine-0.0.1-SNAPSHOT.jar app.jar
+
+RUN bash -c 'touch /app.jar'
+
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/rekolekcje-engine/src/main/resources/application.yml
+++ b/rekolekcje-engine/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   datasource:
     driverClassName: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/rekolekcjedb
+    url: jdbc:postgresql://localhost:5430/rekolekcjedb
     username: postgres
     password: postgres
 

--- a/rekolekcje-engine/src/verify/resources/application-test.yml
+++ b/rekolekcje-engine/src/verify/resources/application-test.yml
@@ -15,7 +15,7 @@ spring:
       enabled: true
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/rekolekcjedb-test
+    url: jdbc:postgresql://localhost:5431/rekolekcjedb-test
     username: postgres
     password: postgres
 


### PR DESCRIPTION
Stworzyłem skrypt `./env.sh`, który stawia dwa kontenery PostreSQL. Jeden jest potrzebny do poprawnego działania aplikacji, a w drugim siedzi baza danych do testów.
Nie jest to najwydajniejsze rozwiązanie i zostanie ono zoptymalizowane.
Użycie:
`./env.sh start` - postawienie dockerów
`./env.sh wipe` - wyczyszczenie dockerów po skończonej pracy.

Do tego powstał Dockerfile dla `fat-jar'a` (btw. chwilę mi zajęło dojście, dlaczego w ogóle stawia całą aplikację, a nie tylko backend :D) oraz `docker-compose`, który stawia całą aplikację i bazę danych.
Używając `docker-compose up` należy upewnić się, że zaoraliśmy inne kontenery z Postgres: `.env.sh wipe`(będzie konflikt) oraz że nie mamy działającego postgresa `sudo service postgresql status` (Tu nie powinno być konfliktów, ale dmuchajmy na zimne).

Dodatkowo zaktualizowałem README.

Nie skonfigurowałem tworzenia dockerów ze skryptem gradla, ale myślę, że pogadamy o tym, bo mam trochę inna wizję.